### PR TITLE
Quoting Added

### DIFF
--- a/dbt_salesforcedatacloud_snowflake/dbt_project.yml
+++ b/dbt_salesforcedatacloud_snowflake/dbt_project.yml
@@ -22,9 +22,19 @@ clean-targets:
   - "target"
   - "dbt_packages"
 
+# https://docs.getdbt.com/reference/project-configs/quoting
+# On Snowflake, quoting is set to false by default. 
+# Whereas most databases will lowercase unquoted identifiers, 
+# Snowflake will uppercase unquoted identifiers.
+# If a model name is lowercased and quoted, then it cannot be referred to without quotes
+# We can override at granular level as needed.
+quoting:
+  database: false
+  schema: false
+  identifier: false
+
 # Configuring models
 # Full documentation: https://docs.getdbt.com/docs/configuring-models
- 
 # These settings can be overridden in the individual model
 # files using the `{{ config(...) }}` macro.
 models:

--- a/dbt_salesforcedatacloud_snowflake/models/schema/schema.yml
+++ b/dbt_salesforcedatacloud_snowflake/models/schema/schema.yml
@@ -4,6 +4,7 @@ models:
     description: "Latest cart activity per session (individualId)"
     columns:
       - name: ssot__IndividualId__c
+        quote: true # # Data Share from Salesforce Data Cluoud is quoted, so we need them as true.
         data_tests:
           - not_null
       - name: lastCartActivity
@@ -18,7 +19,7 @@ models:
         data_tests:
           - not_null
       - name: segmentLabel
-    data_tests:
+        data_tests:
           - not_null
           - accepted_values:
               values: ["HOT", "WARM", "COLD"]

--- a/dbt_salesforcedatacloud_snowflake/models/sources.yml
+++ b/dbt_salesforcedatacloud_snowflake/models/sources.yml
@@ -4,6 +4,7 @@ sources:
     database: WEBSITE_ENGAGEMENT_DATA_SHARE_00DGL000006CKP7UAG
     schema: schema_Snowflake_Data_Share
     # https://docs.getdbt.com/reference/resource-properties/quoting
+    # Data Share from Salesforce Data Cluoud is quoted, so we need them as true.
     quoting:
       database: true
       schema: true


### PR DESCRIPTION
Most databases will lowercase unquoted identifiers, Snowflake will uppercase unquoted identifiers. If a model name is lowercased and quoted, then it cannot be referred to without quotes