### PR TITLE
Cohort based fact model that tracks reactivated users on a monthly basis

### DIFF
--- a/dbt_salesforcedatacloud_snowflake/models/fct/cohort_replays/fct_reactivated_users__cohort_monthly.sql
+++ b/dbt_salesforcedatacloud_snowflake/models/fct/cohort_replays/fct_reactivated_users__cohort_monthly.sql
@@ -1,0 +1,53 @@
+-- ******************************************************************************************
+-- What We Implemented?
+-- ********************
+-- A cohort-based fact model that tracks reactivated users on a monthly basis.
+-- Specifically, we:
+--  -   Pulled users from a reactivated_user_sessions_snapshot table (i.e., users who came back after a break).
+--  -   Bucketed their session into a cohort month (2025-07-01, etc.) using DATE_TRUNC('month', session_starts).
+--  -   Captured relevant fields: party_id, session_id, session_start, gap_days (i.e., number of days they were inactive before this session).
+--  -   (Optionally) enriched it with dim_users to bring in metadata like region, channel, etc.
+
+-- Real-Life Use Case
+-- ******************
+-- Imagine marketing runs a campaign in July targeting users dormant for 30+ days.
+-- We can now:
+--  -   See how many returned in July (cohort_month)
+--  -   Filter by gap_days to segment short vs long reactivation windows
+--  -   Slice by region, channel or campaign_id if joined
+
+-- What You Can Build on Top
+-- *************************
+--  -   Heatmaps of reactivations by month & region
+--  -   Alerting if certain segments stop reactivating
+--  -   LTV by reactivation cohort
+-- ******************************************************************************************
+{{ 
+    config(
+        materialized = 'table',
+        tags = ['cohort', 'reactivation', 'monthly']
+    ) 
+}}
+
+{% set cohort_month_start = "date_trunc('month', current_timestamp())" %}
+{% set cohort_month_end = "dateadd('month', 1, " ~ cohort_month_start ~ ")" %}
+
+WITH reactivations AS (
+  SELECT
+    party_id,
+    session_id,
+    session_starts,
+    date_trunc('month', session_starts) AS cohort_month,
+    gap_days
+  FROM {{ ref('reactivated_user_sessions_snapshot') }}
+  WHERE session_starts >= {{ cohort_month_start }}
+    AND session_starts < {{ cohort_month_end }}
+)
+
+SELECT
+  r.party_id,
+  r.session_id,
+  r.session_starts,
+  r.cohort_month,
+  r.gap_days
+FROM reactivations r

--- a/dbt_salesforcedatacloud_snowflake/models/fct/cohort_replays/reactivated_users.md
+++ b/dbt_salesforcedatacloud_snowflake/models/fct/cohort_replays/reactivated_users.md
@@ -1,0 +1,108 @@
+````markdown
+# 🧠 fct_reactivated_users__cohort_monthly
+
+Replayable monthly cohort model for users who return after inactivity.
+
+---
+
+## 📌 Objective
+
+Track *reactivated users* grouped by the **month they returned**, enabling:
+
+- Behavioral cohorting
+- Reactivation trend analysis
+- Campaign performance insights
+
+---
+
+## 🛠️ Model Info
+
+| Attribute     | Value                                      |
+|---------------|--------------------------------------------|
+| Type          | Fact model (cohort-based)                  |
+| Materialized  | Table                                      |
+| Location      | `models/fct/cohort_replays/`              |
+| Model Name    | `fct_reactivated_users__cohort_monthly`   |
+
+---
+
+## 🧮 Business Logic
+
+A user is considered **reactivated** if:
+- They had a previous session.
+- Then returned after a gap of **30+ days**.
+
+Each user is assigned to a **`cohort_month`** based on their return date.
+
+---
+
+## 📊 Columns
+
+| Column         | Description                              |
+|----------------|------------------------------------------|
+| `party_id`     | Unique user ID                           |
+| `session_id`   | Reactivated session ID                   |
+| `session_starts` | Timestamp of the reactivation session |
+| `cohort_month` | Month when user reactivated              |
+| `gap_days`     | Days since last session                  |
+
+---
+
+## ⚙️ Parameters
+
+By default, it pulls users who reactivated **within the current month**:
+
+```sql
+{% set cohort_month_start = date_trunc('month', current_timestamp()) %}
+{% set cohort_month_end = dateadd('month', 1, cohort_month_start) %}
+````
+
+You can override these for historical replay if needed.
+
+---
+
+## 🚀 Usage
+
+Run the model:
+
+```bash
+dbt run --select fct_reactivated_users__cohort_monthly
+```
+
+Or run all cohort models:
+
+```bash
+dbt run --select path:models/fct/cohort_replays/
+```
+
+---
+
+## 🧩 Extensions
+
+* Join with `dim_users` to add acquisition channel, region, etc.
+* Use `date_spine` for full cohort tracking + retention analysis
+* Plug into dashboards to compare LTV of reactivated vs new users
+
+---
+
+## 📁 Upstream Dependency
+
+* `reactivated_user_sessions_snapshot`: identifies sessions with gap > 30 days
+
+---
+
+## 🧼 Sample Output
+
+| party\_id | session\_id | session\_starts     | cohort\_month       | gap\_days |
+| --------- | ----------- | ------------------- | ------------------- | --------- |
+| user17    | sess4       | 2025-07-31 04:30:00 | 2025-07-01 00:00:00 | 31        |
+| user12    | sess4       | 2025-07-10 18:30:00 | 2025-07-01 00:00:00 | 66        |
+
+---
+
+## 📎 Related
+
+* 📦 `dim_users`
+* 📦 `snapshots/reactivated_user_sessions_snapshot`
+
+```

--- a/dbt_salesforcedatacloud_snowflake/models/schema/schema.yml
+++ b/dbt_salesforcedatacloud_snowflake/models/schema/schema.yml
@@ -16,7 +16,7 @@ seeds:
 
 models:
   - name: stg_cart_sessions
-    description: "Latest cart activity per session (individualId)"
+    description: Latest cart activity per session (individualId)
     columns:
       - name: ssot__IndividualId__c
         quote: true # # Data Share from Salesforce Data Cluoud is quoted, so we need them as true.
@@ -28,7 +28,7 @@ models:
       - name: cartEventCount
 
   - name: fct_cart_abandonment_by_day_segmented
-    description: "Abandoned cart sessions segmented into HOT/WARM/COLD"
+    description: Abandoned cart sessions segmented into HOT/WARM/COLD
     columns:
       - name: EMAIL
         data_tests:
@@ -39,9 +39,9 @@ models:
           - accepted_values:
               values: ["HOT", "WARM", "COLD"]
 
-  - name: cart_reactivated_users
-    description: "Flags users who return and add to cart after a long inactivity period (e.g., >30 days),
-      using session snapshots to detect reactivation."
+  - name: fct_cart_reactivated_users
+    description: Flags users who return and add to cart after a long inactivity period (e.g., >30 days),
+      using session snapshots to detect reactivation.
     columns:
       - name: reactivation_event_id
         description: Unique identifier for the Data Cloud DLO.
@@ -75,3 +75,57 @@ models:
         description: Boolean flag indicating user was inactive for more than threshold period and returned.
         data_tests:
           - not_null
+
+  - name: reactivated_user_sessions_snapshot
+    description: >
+      Identifies reactivated users by comparing session gaps >30 days and joins with their original session cohort.
+    columns:
+      - name: reactivation_event_id
+        description: Unique ID per reactivation event
+        data_tests:
+          - not_null
+          - unique
+
+      - name: party_id
+        description: Salesforce Party ID
+
+      - name: session_id
+        description: Reactivated session ID
+
+      - name: session_number
+        description: Nth session for that user
+
+      - name: gap_days
+        description: Days between last session and this one
+
+      - name: engagement_timestamp
+        description: Date of reactivation event
+
+      - name: reactivation_flag
+        description: Label showing reactivation ("reactivated")
+
+      - name: cohort_month
+        description: YYYY-MM cohort of first session (if joined with dim_users or derived)
+
+  - name: fct_reactivated_users__cohort_monthly
+    description: >
+      Monthly cohort fact table for reactivated users who returned 
+      after at least 30 days of inactivity. Enables behavioral analysis 
+      and reactivation cohorting.
+    columns:
+      - name: party_id
+        description: Unique user identifier.
+        data_tests: 
+          - not_null
+
+      - name: session_id
+        description: Session ID when the user reactivated.
+
+      - name: session_starts
+        description: Timestamp when the reactivation session started.
+
+      - name: cohort_month
+        description: The cohort month the user was reactivated in.
+
+      - name: gap_days
+        description: Days since the last session.


### PR DESCRIPTION
-- ******************************************************************************************
-- What We Implemented?
-- ********************
-- A cohort-based fact model that tracks reactivated users on a monthly basis.
-- Specifically, we:
--  -   Pulled users from a reactivated_user_sessions_snapshot table (i.e., users who came back after a break).
--  -   Bucketed their session into a cohort month (2025-07-01, etc.) using DATE_TRUNC('month', session_starts).
--  -   Captured relevant fields: party_id, session_id, session_start, gap_days (i.e., number of days they were inactive before this session).
--  -   (Optionally) enriched it with dim_users to bring in metadata like region, channel, etc.

-- Real-Life Use Case
-- ******************
-- Imagine marketing runs a campaign in July targeting users dormant for 30+ days.
-- We can now:
--  -   See how many returned in July (cohort_month)
--  -   Filter by gap_days to segment short vs long reactivation windows
--  -   Slice by region, channel or campaign_id if joined

-- What You Can Build on Top
-- *************************
--  -   Heatmaps of reactivations by month & region
--  -   Alerting if certain segments stop reactivating
--  -   LTV by reactivation cohort
-- ******************************************************************************************